### PR TITLE
Docker: Remove eth API flag in cli options

### DIFF
--- a/docker-compose-clients.yml
+++ b/docker-compose-clients.yml
@@ -6,4 +6,4 @@ services:
     command: "--web3-transport http --web3-http-address http://0.0.0.0:8545/ --mb 0 --portal-subnetworks history,beacon --no-upnp --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"
   nimbus-portal:
     image: statusim/nimbus-portal-client:amd64-master-latest
-    command: "--rpc --rpc-address=0.0.0.0 --rpc-api:eth,portal,discovery --storage-capacity=0 --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"
+    command: "--rpc --rpc-address=0.0.0.0 --rpc-api:portal,discovery --storage-capacity=0 --disable-poke ${GLADOS_CLIENT_ARGUMENTS:-}"


### PR DESCRIPTION
Support for eth API is removed in nimbus_portal_client. Without the removal of this flag the startup command will fail.

(Without headers on history network and without state network it is not feasible to provide a meaningful eth API. We do however default enable `web3_clientVersion` method for retrieval of the client version)